### PR TITLE
Replace CGI.parse with internal parser for Ruby 4.0 compatibility

### DIFF
--- a/lib/referer-parser/parser.rb
+++ b/lib/referer-parser/parser.rb
@@ -121,18 +121,25 @@ module RefererParser
 
     protected
 
-    # Parse an x-www-form-urlencoded query string into a Hash of arrays, e.g.
-    # "q=a&q=b&hl=en" => {"q" => ["a", "b"], "hl" => ["en"]}. Missing keys return
-    # an empty array. This replaces CGI.parse, which was removed from Ruby's cgi
-    # stdlib in Ruby 4.0; CGI.unescape (used below) is still available.
+    # Parse an x-www-form-urlencoded query string into a Hash of arrays, mirroring
+    # CGI.parse (removed from Ruby's cgi stdlib in Ruby 4.0; CGI.unescape, used
+    # below, is still available). Matching CGI.parse exactly:
+    #   "q=a&q=b&hl=en" => {"q" => ["a", "b"], "hl" => ["en"]}
+    #   "a&b=1"         => {"a" => [], "b" => ["1"]}  # bare key => empty array
+    #   "a="            => {"a" => [""]}              # key with empty value
+    # and missing keys return an empty array.
     def parse_query(query)
-      params = Hash.new { |hash, key| hash[key] = [] }
+      params = {}
 
       query.to_s.split('&').each do |pair|
         key, value = pair.split('=', 2).map { |component| CGI.unescape(component) }
+        next if key.nil?
+
+        params[key] ||= []
         params[key] << value if value
       end
 
+      params.default = [].freeze
       params
     end
 

--- a/lib/referer-parser/parser.rb
+++ b/lib/referer-parser/parser.rb
@@ -103,7 +103,7 @@ module RefererParser
 
         # Parse parameters if the referer uses them
         if url.query && referer_data[:parameters]
-          query_params = CGI.parse(url.query)
+          query_params = parse_query(url.query)
           referer_data[:parameters].each do |param|
             # If there is a matching parameter, get the first non-blank value
             unless (values = query_params[param]).empty?
@@ -120,6 +120,21 @@ module RefererParser
     end
 
     protected
+
+    # Parse an x-www-form-urlencoded query string into a Hash of arrays, e.g.
+    # "q=a&q=b&hl=en" => {"q" => ["a", "b"], "hl" => ["en"]}. Missing keys return
+    # an empty array. This replaces CGI.parse, which was removed from Ruby's cgi
+    # stdlib in Ruby 4.0; CGI.unescape (used below) is still available.
+    def parse_query(query)
+      params = Hash.new { |hash, key| hash[key] = [] }
+
+      query.to_s.split('&').each do |pair|
+        key, value = pair.split('=', 2).map { |component| CGI.unescape(component) }
+        params[key] << value if value
+      end
+
+      params
+    end
 
     # Determine the correct name_key for this host and path
     def domain_and_name_key_for(uri)


### PR DESCRIPTION
## Problem

Ruby 4.0 slimmed down the `cgi` standard library and removed `CGI.parse`. As a result, `RefererParser::Parser#parse` raises when a referer URL has a query string:

```
undefined method 'parse' for class CGI (NoMethodError)
    query_params = CGI.parse(url.query)
```

(`CGI.escape`/`CGI.unescape` remain available; only `CGI.parse` and the larger CGI surface were removed.)

## Fix

Replace the `CGI.parse` call with a small internal `parse_query` helper that returns the same `Hash`-of-arrays shape, using the still-available `CGI.unescape` for value decoding. No new dependencies, and it remains compatible with older Rubies.

## Verification

Tested on Ruby 4.0.5 against real referer URLs:

- `+` and `%XX` decoding (`q=hello+world`, `q=ruby%204`)
- repeated keys (`q=&q=second` -> picks first non-blank)
- params present but search term absent -> `nil`
- no query string -> `nil`
- malformed/bare/empty keys (`q=x&flag&=&weird`) -> no longer raises

All produce the expected results; behavior matches the previous `CGI.parse`-based output.